### PR TITLE
Update init.php

### DIFF
--- a/init.php
+++ b/init.php
@@ -1,7 +1,7 @@
 <?php
-eval(getPluginConf("logoff"));
+eval(FileUtil::getPluginConf("logoff")); // update to work with ruTorrent > 4.x
 
-$me = getUser();
+$me = User::getUser(); // update to work with ruTorrent > 4.x
 $users = array();
 
 $dirs = scandir($rootPath . "/share/users/");


### PR DESCRIPTION
With ruTorrent 4.3.4 this file generate a crash of ruTorrent with this plugin. This modifications keep logoff plugin to work with ruTorrent 4.3.4. Discus here : https://github.com/Novik/ruTorrent/discussions/2676